### PR TITLE
One cannot install pyqt with pip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 spur
 sphinx_rtd_theme
-Crypto.Cipher
 simple-crypt>=4.0.0
+pycrypto

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 spur
-PyQt5
 sphinx_rtd_theme
 Crypto.Cipher
 simple-crypt>=4.0.0


### PR DESCRIPTION
You have to use your distributions pkg mnger instead or download and install from http://www.riverbankcomputing.com/software/pyqt/download5

Debian like : apt-get install python3-pyqt5