### PR TITLE
adjust control parsing and methods to find unused drive letters

### DIFF
--- a/oPB/core/datadefinition.py
+++ b/oPB/core/datadefinition.py
@@ -991,44 +991,44 @@ class ControlFileData(QObject, LogMixin):
                                 self.packageversion = value
                             else:
                                 self.productversion = value
-                        if param == "DEPENDS":
+                        elif param == "DEPENDS":
                             self.depends = value
-                        if param == "INCREMENTAL":
+                        elif param == "INCREMENTAL":
                             self.incremental = value
-                        if param == "TYPE":
+                        elif param == "TYPE":
                             self.type = value
-                        if param == "ID":
+                        elif param == "ID":
                             self.id = value
-                        if param == "NAME":
+                        elif param == "NAME":
                             self.name = value
-                        if param == "DESCRIPTION":
+                        elif param == "DESCRIPTION":
                             self.description = value
-                        if param == "ADVICE":
+                        elif param == "ADVICE":
                             self.advice = value
-                        if param == "PRIORITY":
+                        elif param == "PRIORITY":
                             self.priority = int(value)
-                        if param == "LICENSEREQUIRED":
+                        elif param == "LICENSEREQUIRED":
                             self.licenseRequired = value
-                        if param == "PRODUCTCLASSES":
+                        elif param == "PRODUCTCLASSES":
                             pass
-                        if param == "SETUPSCRIPT":
+                        elif param == "SETUPSCRIPT":
                             self.setupScript = value
-                        if param == "UNINSTALLSCRIPT":
+                        elif param == "UNINSTALLSCRIPT":
                             self.uninstallScript = value
-                        if param == "UPDATESCRIPT":
+                        elif param == "UPDATESCRIPT":
                             self.updateScript = value
-                        if param == "ALWAYSSCRIPT":
+                        elif param == "ALWAYSSCRIPT":
                             self.alwaysScript = value
-                        if param == "ONCESCRIPT":
+                        elif param == "ONCESCRIPT":
                             self.onceScript = value
-                        if param == "CUSTOMSCRIPT":
+                        elif param == "CUSTOMSCRIPT":
                             self.customScript = value
-                        if param == "USERLOGINSCRIPT":
+                        elif param == "USERLOGINSCRIPT":
                             self.userLoginScript = value
                     else:
                         if lastparam == "DESCRIPTION":
                             self.description += "\n"+lines[currentline][:-1]
-                        if lastparam == "ADVICE":
+                        elif lastparam == "ADVICE":
                             self.advice += "\n"+lines[currentline][:-1]
 
                     currentline += 1
@@ -1051,13 +1051,13 @@ class ControlFileData(QObject, LogMixin):
 
                         if param == "ACTION":
                             dep.dependencyForAction = value
-                        if param == "REQUIREDPRODUCT":
+                        elif param == "REQUIREDPRODUCT":
                             dep.requiredProductId = value
-                        if param == "REQUIREDACTION":
+                        elif param == "REQUIREDACTION":
                             dep.requiredAction = value
-                        if param == "REQUIREDSTATUS":
+                        elif param == "REQUIREDSTATUS":
                             dep.requiredInstallationStatus = value
-                        if param == "REQUIREMENTTYPE":
+                        elif param == "REQUIREMENTTYPE":
                             dep.requirementType = value
 
                     currentline += 1
@@ -1082,16 +1082,16 @@ class ControlFileData(QObject, LogMixin):
 
                         if param == 'NAME':
                             prop.name = value
-                        if param == 'TYPE':
+                        elif param == 'TYPE':
                             prop.type = value
                             lasttype = value
-                        if param == 'MULTIVALUE':
+                        elif param == 'MULTIVALUE':
                             prop.multivalue = value
-                        if param == 'EDITABLE':
+                        elif param == 'EDITABLE':
                             prop.editable = value
-                        if param == 'DESCRIPTION':
+                        elif param == 'DESCRIPTION':
                             prop.description = value
-                        if param == 'VALUES':
+                        elif param == 'VALUES':
                             # tmp = value[2:len(value)-2]
                             # tmp = tmp.replace('\\"', '_$%&%DUMMY%&%$_')
                             # tmp = tmp.replace('"', '')
@@ -1099,7 +1099,7 @@ class ControlFileData(QObject, LogMixin):
                             # tmp = tmp.replace('\\\\', '\\')
                             # prop.values = tmp
                             if value != "": prop.values = json.loads(value)
-                        if param == 'DEFAULT':
+                        elif param == 'DEFAULT':
                             if lasttype == 'bool':
                                 prop.default = value
                             else:

--- a/oPB/core/datadefinition.py
+++ b/oPB/core/datadefinition.py
@@ -1002,9 +1002,9 @@ class ControlFileData(QObject, LogMixin):
                         if param == "NAME":
                             self.name = value
                         if param == "DESCRIPTION":
-                            self.description = value + "\n"  # re-add first stripped newline char
+                            self.description = value
                         if param == "ADVICE":
-                            self.advice = value + "\n"  # re-add first stripped newline char
+                            self.advice = value
                         if param == "PRIORITY":
                             self.priority = int(value)
                         if param == "LICENSEREQUIRED":
@@ -1027,9 +1027,9 @@ class ControlFileData(QObject, LogMixin):
                             self.userLoginScript = value
                     else:
                         if lastparam == "DESCRIPTION":
-                            self.description += lines[currentline]
+                            self.description += "\n"+lines[currentline][:-1]
                         if lastparam == "ADVICE":
-                            self.advice += lines[currentline]
+                            self.advice += "\n"+lines[currentline][:-1]
 
                     currentline += 1
                     if currentline > lines_count: break
@@ -1165,7 +1165,7 @@ class ControlFileData(QObject, LogMixin):
                 file.write("type: " + self.type + "\n")
                 file.write("id: " + self.id + "\n")
                 file.write("name: " + self.name + "\n")
-                file.write("description: " + self.description.strip() + "\n")
+                file.write("description: " + self.description + "\n")
                 file.write("advice: " + self.advice + "\n")
                 file.write("version: " + self.productversion + "\n")
                 file.write("priority: " + str(self.priority) + "\n")

--- a/oPB/core/tools.py
+++ b/oPB/core/tools.py
@@ -37,6 +37,7 @@ import socket
 import sys
 import os
 import re
+import string
 from itertools import cycle
 
 if sys.platform.lower().startswith('win'):

--- a/oPB/core/tools.py
+++ b/oPB/core/tools.py
@@ -315,7 +315,7 @@ class Helper():
             return []
         drive_bitmask = ctypes.cdll.kernel32.GetLogicalDrives()
         return list(itertools.compress(string.ascii_uppercase,
-               map(lambda x:ord(x) - ord('1'), bin(drive_bitmask)[:1:-1])))
+               map(lambda x:x=='0', bin(drive_bitmask+2**26)[:1:-1])))
 
     @classmethod
     def get_existing_drive_letters(cls) -> list:
@@ -331,7 +331,7 @@ class Helper():
             return []
         drive_bitmask = ctypes.cdll.kernel32.GetLogicalDrives()
         return list(itertools.compress(string.ascii_uppercase,
-               map(lambda x:ord(x) - ord('0'), bin(drive_bitmask)[:1:-1])))
+               map(lambda x:x=='1', bin(drive_bitmask+2**26)[:1:-1])))
 
     @classmethod
     def test_port(cls, host: str, port: str, timeout: int = 2):


### PR DESCRIPTION
This pull request includes two independent adjustments.

1. Control parsing
   - Add support to unknown properties of control files (fixes #17)
   - fix description and device handling (no extra newline on each save for advice and equal handling of both to ensure GUI content equals content of the control file without an extra newline in the GUI)
2. Fix the method to find unused drive letters to automount drives on windows if:
   - high letter not in use
   - net drives are in disconnected state (because they will ignored by the used API)

If you want to separate this to two please give feedback. This is my first pull request at all... 

P.S. Online available is a v8.4.4 but this is not checked in, so this changes are rebased against v8.4.2