### PR TITLE
Block save button while editing property or dependency

### DIFF
--- a/oPB/gui/mainwindow.py
+++ b/oPB/gui/mainwindow.py
@@ -721,6 +721,7 @@ class MainWindow(MainWindowBase, MainWindowUI, LogMixin, EventMixin):
         self.cmbDepRequirement.setEnabled(False)
         self.btnDepModify.setEnabled(False)
         self.btnDepAdd.setEnabled(True)
+        self.btnSave.setEnabled(True)
 
         # disconnect if there has been an editing event before
         try:
@@ -761,6 +762,7 @@ class MainWindow(MainWindowBase, MainWindowUI, LogMixin, EventMixin):
         self.cmbPropDef.setEnabled(False)
         self.btnPropModify.setEnabled(False)
         self.btnPropAdd.setEnabled(True)
+        self.btnSave.setEnabled(True)
 
         # disconnect if there has been an editing event before
         try:
@@ -819,6 +821,7 @@ class MainWindow(MainWindowBase, MainWindowUI, LogMixin, EventMixin):
         self.btnDepAdd.setEnabled(False)
         self.btnDepDelete.setEnabled(False)
         self.btnDepEdit.setEnabled(False)
+        self.btnSave.setEnabled(False)
 
         # special combobox checker, connect only on edit
         self.cmbDepReqAction.currentIndexChanged.connect(self.check_combobox_selection)
@@ -835,6 +838,7 @@ class MainWindow(MainWindowBase, MainWindowUI, LogMixin, EventMixin):
         self.btnPropAdd.setEnabled(False)
         self.btnPropDelete.setEnabled(False)
         self.btnPropEdit.setEnabled(False)
+        self.btnSave.setEnabled(False)
 
         if self._parent.model_properties.item(self.datamapper_properties.currentIndex(), 1).text() == 'bool':
             self.datamapper_properties.removeMapping(self.inpPropDef)


### PR DESCRIPTION
As described in issue #15 some people (like me) add/edit a property/dependency and forget to accept this changes and just save the project. Then we lose the wonderful description of the property and don't want to do that so beautiful a second time ;-)
The patch will disable the save button (like some others) until we accept the changes (fixes #15 ).