### PR TITLE
Add "once" as possible action of product dependency

### DIFF
--- a/oPB/core/datadefinition.py
+++ b/oPB/core/datadefinition.py
@@ -255,7 +255,7 @@ class ProductDependency(object):
     @requiredAction.setter
     def requiredAction(self, value):
         # create new exception handling vor depdencies
-        if not str(value).strip() in ["", "setup", "uninstall", "update", "custom"]:
+        if not str(value).strip() in ["", "setup", "uninstall", "update", "custom", "once"]:
             raise ValueError(translate("ProductDependency", "Incorrect value for requiredAction: " + str(value).strip()))
         self._requiredAction = str(value).strip()
 

--- a/oPB/ui/mainwindow.ui
+++ b/oPB/ui/mainwindow.ui
@@ -1310,6 +1310,11 @@
               <string>custom</string>
              </property>
             </item>
+            <item>
+             <property name="text">
+              <string>once</string>
+             </property>
+            </item>
            </widget>
           </item>
           <item row="3" column="0">


### PR DESCRIPTION
This PR add the action request "once" as available option for a product dependency.

- Fix loading of existing packages with this value
- Add option to UI to select once for new entries

Note: (qt) resource files are not included, because they would conflict with other changes...